### PR TITLE
added testing frameworks and tools to dev dependencies closes #109

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.22.0",
     "babel-preset-stage-2": "^6.22.0",
+    "chai": "^3.5.0",
+    "chai-enzyme": "^0.6.1",
+    "enzyme": "^2.7.1",
     "eslint": "^3.15.0",
     "eslint-config": "^0.3.0",
     "eslint-config-semistandard": "^7.0.0",
@@ -58,7 +61,12 @@
     "eslint-plugin-promise": "^3.4.1",
     "eslint-plugin-react": "^6.9.0",
     "eslint-plugin-standard": "^2.0.1",
+    "mocha": "^3.2.0",
+    "react-addons-test-utils": "^15.4.2",
+    "sinon": "^1.17.7",
+    "sinon-chai": "^2.8.0",
     "standard": "^8.6.0",
+    "supertest": "^3.0.0",
     "webpack": "^2.2.1"
   }
 }


### PR DESCRIPTION
Added the following libraries: 

- mocha
- chai
- enzyme
- chai-enzyme
- supertest
- sinon
- sinon-chai
- react-addons-test-utils (a peer dependency of enzyme for React v15.0 +)